### PR TITLE
Browser-friendly stylelint build

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,10 +12,6 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/PrettyCSS/-/PrettyCSS-0.3.12.tgz"
     },
-    "stylelint": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-7.5.0.tgz"
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
@@ -6273,6 +6269,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
     },
+    "string-replace-loader": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-1.0.5.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        }
+      }
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
@@ -6312,6 +6318,370 @@
     "strip-json-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+    },
+    "stylelint": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-7.5.0.tgz",
+      "dependencies": {
+        "colorguard": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/colorguard/-/colorguard-1.2.0.tgz",
+          "dependencies": {
+            "color-diff": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            },
+            "pipetteur": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/pipetteur/-/pipetteur-2.0.3.tgz",
+              "dependencies": {
+                "onecolor": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.4.tgz"
+                },
+                "synesthesia": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/synesthesia/-/synesthesia-1.0.1.tgz",
+                  "dependencies": {
+                    "css-color-names": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "plur": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+              "dependencies": {
+                "irregular-plurals": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz"
+                }
+              }
+            },
+            "yargs": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+            }
+          }
+        },
+        "cosmiconfig": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            },
+            "require-from-string": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
+            }
+          }
+        },
+        "doiuse": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/doiuse/-/doiuse-2.5.0.tgz",
+          "dependencies": {
+            "css-rule-stream": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
+              "dependencies": {
+                "css-tokenize": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "jsonfilter": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "0.8.4",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "stream-combiner": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+                  "dependencies": {
+                    "duplexer": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ldjson-stream": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
+              "dependencies": {
+                "split2": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+            },
+            "through2": {
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.34",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "yargs": {
+              "version": "3.32.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "execall": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+          "dependencies": {
+            "clone-regexp": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
+              "dependencies": {
+                "is-regexp": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz"
+                },
+                "is-supported-regexp-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            }
+          }
+        },
+        "globjoin": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz"
+        },
+        "html-tags": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.1.1.tgz"
+        },
+        "ignore": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz"
+        },
+        "known-css-properties": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.0.5.tgz"
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz"
+        },
+        "normalize-selector": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz"
+        },
+        "postcss-less": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz"
+        },
+        "postcss-media-query-parser": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz"
+        },
+        "postcss-reporter": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz"
+        },
+        "postcss-resolve-nested-selector": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz"
+        },
+        "postcss-scss": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.3.1.tgz",
+          "dependencies": {
+            "postcss": {
+              "version": "5.2.5",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.5.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+        },
+        "specificity": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.0.tgz"
+        },
+        "string-width": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+            }
+          }
+        },
+        "style-search": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz"
+        },
+        "stylehacks": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-2.3.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "plur": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+              "dependencies": {
+                "irregular-plurals": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz"
+                }
+              }
+            },
+            "read-file-stdin": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
+              "dependencies": {
+                "gather-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "write-file-stdout": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz"
+            }
+          }
+        },
+        "sugarss": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-0.2.0.tgz",
+          "dependencies": {
+            "postcss": {
+              "version": "5.2.5",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.5.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "svg-tags": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz"
+        }
+      }
+    },
+    "substitute-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/substitute-loader/-/substitute-loader-1.0.0.tgz"
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "license": "MIT",
   "dependencies": {
     "PrettyCSS": "^0.3.12",
-    "stylelint": "^7.5.0",
     "base64-js": "^1.0.2",
     "bowser": "^1.4.5",
     "brace": "^0.8.0",
@@ -77,6 +76,7 @@
     "redux-logger": "^2.5.0",
     "redux-thunk": "^2.1.0",
     "slowparse": "^1.1.4",
+    "stylelint": "^7.5.0",
     "text-encoding": "^0.6.0"
   },
   "engines": {
@@ -142,7 +142,8 @@
     "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
     "postcss-cssnext": "^2.8.0",
     "raw-loader": "^0.5.1",
-    "stylelint": "https://registry.npmjs.org/stylelint/-/stylelint-7.5.0.tgz",
+    "string-replace-loader": "^1.0.5",
+    "substitute-loader": "^1.0.0",
     "transform-loader": "^0.2.3",
     "webpack": "^2.1.0-beta.25",
     "webpack-dev-middleware": "^1.8.2",

--- a/src/util/minimalStylelint.js
+++ b/src/util/minimalStylelint.js
@@ -1,0 +1,29 @@
+import partial from 'lodash/partial';
+import getPostcssResult from 'stylelint/dist/getPostcssResult';
+import lintSource from 'stylelint/dist/lintSource';
+
+const stylelint = {};
+
+const config = {
+  rules: {
+    'declaration-block-trailing-semicolon': ['always'],
+  },
+  pluginFunctions: {},
+};
+
+Object.assign(stylelint, {
+  _postcssResultCache: new Map(),
+  _options: {},
+
+  getConfigForFile() {
+    return Promise.resolve({config});
+  },
+
+  isPathIgnored() {
+    return Promise.resolve(false);
+  },
+
+  _getPostcssResult: partial(getPostcssResult, stylelint),
+});
+
+export default (code) => lintSource(stylelint, {code});

--- a/src/validations/linters.js
+++ b/src/validations/linters.js
@@ -4,9 +4,9 @@ import htmllint from 'htmllint';
 import HTMLInspector from 'html-inspector';
 import {JSHINT as jshint} from 'jshint';
 import prettyCSS from 'PrettyCSS';
-import stylelint from 'stylelint';
 import Slowparse from 'slowparse/src';
 import SlowparseHTMLParser from 'slowparse/src/HTMLParser';
+import stylelint from '../util/minimalStylelint';
 
 SlowparseHTMLParser.prototype.omittableCloseTagHtmlElements = [];
 
@@ -17,6 +17,6 @@ export {
   HTMLInspector,
   jshint,
   prettyCSS,
-  stylelint,
   Slowparse,
+  stylelint,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,10 @@
 const path = require('path');
 const webpack = require('webpack');
+const escapeRegExp = require('lodash/escapeRegExp');
+
+function matchModule(modulePath) {
+  return new RegExp(`\\/node_modules\\/${escapeRegExp(modulePath)}`);
+}
 
 module.exports = {
   entry: './src/application.js',
@@ -30,17 +35,32 @@ module.exports = {
         test: /\.js$/,
         include: [
           path.resolve(__dirname, 'node_modules/PrettyCSS'),
-          path.resolve(__dirname, 'node_modules/stylelint'),
-          path.resolve(__dirname, 'node_modules/browserslist'),
-          path.resolve(__dirname, 'node_modules/graceful-fs'),
-          path.resolve(__dirname, 'node_modules/postcss'),
-          path.resolve(__dirname, 'node_modules/sugarss'),
-          path.resolve(__dirname, 'node_modules/fs.realpath'),
-          path.resolve(__dirname, 'node_modules/postcss-scss'),
-          path.resolve(__dirname, 'node_modules/autoprefixer'),
           path.resolve(__dirname, 'node_modules/css'),
         ],
         loader: 'transform/cacheable?brfs',
+      },
+      {
+        test: /\.js$/,
+        include: [
+          matchModule('postcss/lib/previous-map'),
+          matchModule('stylelint/dist/getPostcssResult'),
+        ],
+        loader: 'string-replace',
+        query: {
+          search: /require\(['"]fs['"]\)/,
+          replace: '{}',
+        },
+      },
+      {
+        test: /\.js$/,
+        include: [
+          path.resolve(
+            __dirname,
+            'node_modules/stylelint/dist/utils/isAutoprefixable'
+          ),
+        ],
+        loader: 'substitute',
+        query: {content: '() => false'},
       },
       {
         test: /\.js$/,
@@ -71,6 +91,18 @@ module.exports = {
         test: /\.js$/,
         include: [
           path.resolve(__dirname, 'node_modules/brace/worker'),
+          path.resolve(
+            __dirname,
+            'node_modules/stylelint/dist/rules/no-unsupported-browser-features'
+          ),
+          path.resolve(
+            __dirname,
+            'node_modules/stylelint/dist/rules/no-browser-hacks'
+          ),
+          matchModule('autoprefixer'),
+          matchModule('postcss-scss'),
+          matchModule('postcss-less'),
+          matchModule('sugarss'),
         ],
         loader: 'null',
       },
@@ -95,7 +127,7 @@ module.exports = {
       'github-api': 'github-api/lib',
       'html-inspector$': 'html-inspector/html-inspector.js',
     },
-    extensions: ['.js', '.jsx'],
+    extensions: ['.js', '.jsx', '.json'],
   },
   devtool: 'source-map',
 };


### PR DESCRIPTION
The default `stylelint` module wants to load configuration files from the filesystem in a dynamic way that isn’t possible with `brfs`. We don’t actually need the file-loading behavior, so instead, we hand-roll a `stylelint` object in the same manner as [`createStylelint`](https://github.com/stylelint/stylelint/blob/7.5.0/src/createStylelint.js), but using configuration defined in code rather than the filesystem. This definitely builds in knowledge of some non-public APIs in `stylelint`, but I can’t think of a better approach.

Also a decent amount of Webpack wrangling to get the modules we do import from stylelint to build. In particular, they *still* want to hit the filesystem, although they don’t actually need to in order to work for us. So, instead of building those modules with `brfs`, just use the string replace loader to turn `require("fs")` into a null object; use the `substitute` loader to stub out the `isAutoprefixable` method; and use the null module loader to stub out rules that want access to a gigantic database of browser capabilities. The usage of string-replacement is a fragile hack, but I can’t think of another way to *only* stub out `fs` in that particular context.

Right now, the actual rules stylelint will use are defined in the `minimalStylelint` module, which isn’t ideal (better to define them in the validator and pass them as an argument) but does work fine.